### PR TITLE
Map options

### DIFF
--- a/app/callbackModules/pagecallbacks.py
+++ b/app/callbackModules/pagecallbacks.py
@@ -19,7 +19,7 @@ def render_page_content(pathname):
     elif pathname == "/magnitudes":
         content = viewModules.magnitudeview_layout
     elif pathname == "/map":
-        content = viewModules.mapview_layout
+        content = viewModules.mapview_layout()
     elif pathname == "/map3d":
         content = viewModules.map_3d_view_layout
     elif pathname == "/energy":

--- a/app/callbackModules/scatterplotmap.py
+++ b/app/callbackModules/scatterplotmap.py
@@ -1,13 +1,9 @@
 import logging
 
-import dash_bootstrap_components as dbc
-from dash import html
 from dash.dependencies import Input, Output
-import plotly.express as px
 import plotly.graph_objects as go
-import pandas as pd
 
-from ..data import database, calculations
+from ..data import database, calculations, copernicus_data
 
 # load app
 from ..server import app
@@ -16,43 +12,74 @@ logger = logging.getLogger(__name__)
 
 
 @app.callback(
-    Output("scatter-map-2d", "figure"),
+    Output("map-viz", "figure"),
     [
         Input('date-picker', 'start_date'),
         Input('date-picker', 'end_date'),
         Input('magnitude-slider', 'value'),
-        Input("depth-slider", "value")
+        Input("depth-slider", "value"),
+        Input("map-style", "value"),
+        Input("map-overlay", "value"),
+        Input("map-type", "value"),
     ]
 )
-def map_eq(start_date, end_date, magnitude_range, depth_range):
+def map_eq(start_date, end_date, magnitude_range, depth_range, map_style, map_overlay, map_type):
     df = database.get_unfiltered_df()
     date_mask, mag_mask, depth_mask = calculations.filter_data(df, start_date, end_date, magnitude_range, depth_range)
 
     df = df[date_mask & mag_mask & depth_mask]
 
+    ovr = {}
+    if map_overlay:
+        type_raw = map_overlay.split("_")[-1]
+        if type_raw == "Point":
+            type = "circle"
+        if type_raw == "Area":
+            type = "fill"
+        if type_raw == "Line":
+            type = "line"
+        overlay = copernicus_data.overlay(map_overlay)
+        ovr = {
+            "below": 'traces',
+            'type': type,
+            'circle': {"radius": 10},
+            'color': "red",
+            "opacity": 0.75,
+            "source": overlay
+        }
+
     # To prevent exceptions, return empty figure if there are no values
     try:
-        fig = go.Figure(go.Scattermapbox(
-            lat=df.lat,
-            lon=df.lon,
-            mode="markers",
-            marker={
-                "size": df["mag"] * 2 ** 2,
-                "color": df.mag,
-                "showscale": True,
-            },
-        ))
+        if map_type == "scatter":
+            fig = go.Figure(go.Scattermapbox(
+                lat=df.lat,
+                lon=df.lon,
+                mode="markers",
+                marker={
+                    "size": df["mag"] * 2 ** 2,
+                    "color": df.mag,
+                    "showscale": True,
+                },
+            ))
+        elif map_type == "heatmap":
+            fig = go.Figure(go.Densitymapbox(
+                lat=df.lat,
+                lon=df.lon,
+                z=df.mag,
+                radius=df["mag"] ** 2,
+            ))
+        else:
+            raise Exception("map type unknown")
+
         fig.update_layout(
-            mapbox_style="open-street-map",
-            mapbox_center_lon=-17.8470,
-            mapbox_center_lat=28.6716,
-            mapbox_zoom=8,
-            # marker_color=df.mag
-        )
-        fig.update_layout(
+            mapbox_style=map_style,
             margin={"r": 0, "t": 0, "l": 0, "b": 0},
             uirevision=f"{start_date}{end_date}",
             showlegend=False,
+            mapbox_center_lon=-17.8470,
+            mapbox_center_lat=28.6716,
+            mapbox_zoom=8,
+            mapbox_layers=[ovr]
         )
 
     except Exception as e:

--- a/app/components/map_options.py
+++ b/app/components/map_options.py
@@ -34,7 +34,7 @@ def map_overlay():
         id="map-overlay",
         options=[{'label': v, 'value': k} for k, v in opts.items()],
         value="",
-        placeholder="Select an overlay...",
+        placeholder="Select an overlay... (WIP)",
         className="map-option"
     )
 

--- a/app/components/map_options.py
+++ b/app/components/map_options.py
@@ -1,0 +1,48 @@
+from dash import html, dcc
+
+from ..data.copernicus_data import get_copernicus_data, layer_options
+from ..server import cache
+
+
+MAP_STYLES = {
+    "Open street map": "open-street-map",
+    "Carto Positron": "carto-positron",
+    "Carto Dark Matter": "carto-darkmatter",
+    "Stamen Terrain": "stamen-terrain",
+    "Stamen Toner": "stamen-toner",
+    "Stamnen Watercolor": "stamen-watercolor"
+}
+
+MAP_TYPES = {
+    "Default": "scatter",
+    "Heatmap": "heatmap"
+}
+
+def map_option():
+    return dcc.Dropdown(
+        id="map-style",
+        options=[{'label': k, 'value': v} for k, v in MAP_STYLES.items()],
+        value="open-street-map",
+        className="map-option"
+    )
+
+
+def map_overlay():
+    overlay_layers = get_copernicus_data()
+    opts = layer_options(overlay_layers)
+    return dcc.Dropdown(
+        id="map-overlay",
+        options=[{'label': v, 'value': k} for k, v in opts.items()],
+        value="",
+        placeholder="Select an overlay...",
+        className="map-option"
+    )
+
+
+def map_type():
+    return dcc.Dropdown(
+        id="map-type",
+        options=[{'label': k, 'value': v} for k, v in MAP_TYPES.items()],
+        value="scatter",
+        className="map-option"
+    )

--- a/app/data/copernicus_data.py
+++ b/app/data/copernicus_data.py
@@ -1,0 +1,156 @@
+import logging
+from zipfile import ZipFile
+from urllib.parse import urlparse
+import os
+import json
+
+import requests
+from georss_generic_client import GenericFeed
+import lxml.etree as ET
+
+from ..server import cache
+
+
+logger = logging.getLogger(__name__)
+
+COPERNICUS_JSON = os.path.join(os.path.abspath(os.sep), "tmp", "copernicus_data.json")
+COPERNICUS_FEED_URL = "https://emergency.copernicus.eu/mapping/list-of-components/EMSR546/aemfeed"
+
+
+def copernicus_entries():
+    logger.info("Fetching Copernicus publication")
+
+    feed = GenericFeed(
+        (28.668274, -17.854698),
+        filter_categories=["Product: Production finished", "Product: Quality approved"],
+        url=COPERNICUS_FEED_URL
+    )
+    status, entries = feed.update()
+
+    if status != "OK":
+        raise Exception(f"Failed to get entries from Copernicus: {status}")
+
+    return entries
+
+
+def entry_data_url(entry):
+    logger.info("Retrieving data url from copernicus publication")
+
+    parser = ET.HTMLParser()
+    html_tree = ET.fromstring(entry.description, parser)
+
+    page_link = html_tree.xpath("./body/div/div/a")[0].attrib.get("href")
+
+    r = requests.get(page_link)
+    html_tree = ET.fromstring(r.content, parser)
+
+    path = html_tree.xpath("//div[contains(@class, 'field-content')]/a")[0].attrib.get("href")
+
+    url = "https://emergency.copernicus.eu" + path
+
+    return url
+
+
+def download_copernicus_zip(url):
+    logger.info("Downloading archive from Copernicus website")
+
+    filename = str(urlparse(url).path.split("/")[-1])
+    filepath = os.path.join(os.path.abspath(os.sep), "tmp", filename)
+
+    # Check if today data was downloaded already
+    if os.path.exists(filepath):
+        logger.info("Data previously downloaded, using cache.")
+        return filepath
+
+    headers = {
+        "User-Agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:93.0) Gecko/20100101 Firefox/93.0"
+    }
+
+    forms_data_clicked = {
+        "confirmation": "1",
+        "op": "+Download+file+",
+        "form_id": "emsmapping_disclaimer_download_form"
+    }
+
+    r = requests.post(url, headers=headers, data=forms_data_clicked)
+
+    if r.status_code != 200:
+        raise ConnectionError(r.status_code, r.reason)
+
+    with open(filepath, "wb") as outf:
+        outf.write(r.content)
+
+    return filepath
+
+
+def extract_copernicus_layers(filepath):
+
+    layers = {}
+    with ZipFile(filepath) as zp:
+        for f in zp.namelist():
+            if f.endswith(".json"):
+                with zp.open(f) as zf:
+                    layers[layer_name(f)] = json.load(zf)
+
+    with open(COPERNICUS_JSON, "w") as outf:
+        json.dump(layers, outf, indent=2)
+
+    return list(layers.keys())
+
+
+def layer_options(layers):
+    layers_matcher = {
+        "areaOfInterest_Area": "Area of interest",
+        "builtUp_Point": "Built up",
+        "facilities_Area": "Facilities Area",
+        "hydrography_Line": "Hydrography",
+        "imageFootprint_Area": "Image Footprint",
+        "naturalLandUse_Area": "Natural Land Use",
+        "observedEvent_Area": "Lava Flow",
+        "observedEvent_Point": "Current Vents",
+        "physiography_Line": "Physiography",
+        "transportation_Line": "Transportation",
+    }
+
+    return {k: v for k, v in layers_matcher.items() if k in layers}
+
+
+def layer_name(filename):
+
+    sel = filename.split("_")[4]
+    name = sel[0:-1]
+    geometry = sel[-1]
+
+    GEOMETRY = {
+        "A": "Area",
+        "P": "Point",
+        "L": "Line"
+    }
+
+    return "_".join([name, GEOMETRY.get(geometry, "Unknown")])
+
+
+def overlay(name):
+
+    with open(COPERNICUS_JSON) as inf:
+        overlays = json.load(inf)
+        return overlays.get(name)
+
+
+@cache.memoize(timeout=3600*24)
+def get_copernicus_data():
+
+    entries = copernicus_entries()
+    data_url = entry_data_url(entries[-1])
+    data_filepath = download_copernicus_zip(data_url)
+
+    layers = extract_copernicus_layers(data_filepath)
+
+    return layers
+
+
+if __name__ == '__main__':
+    layers = get_copernicus_data()
+
+    with open("copernicus_data.json", "w") as outf:
+        json.dump(layers, outf, indent=2)

--- a/app/data/copernicus_data.py
+++ b/app/data/copernicus_data.py
@@ -100,16 +100,16 @@ def extract_copernicus_layers(filepath):
 
 def layer_options(layers):
     layers_matcher = {
-        "areaOfInterest_Area": "Area of interest",
-        "builtUp_Point": "Built up",
-        "facilities_Area": "Facilities Area",
-        "hydrography_Line": "Hydrography",
+        "areaOfInterest_Area": "Area of interest (Copernicus observed area)",
+        "builtUp_Point": "Built up (Building destroyed or damaged. WIP)",
+        "facilities_Area": "Facilities Area (Not too sure)",
+        "hydrography_Line": "Hydrography (Water lines? WIP)",
         "imageFootprint_Area": "Image Footprint",
-        "naturalLandUse_Area": "Natural Land Use",
-        "observedEvent_Area": "Lava Flow",
-        "observedEvent_Point": "Current Vents",
-        "physiography_Line": "Physiography",
-        "transportation_Line": "Transportation",
+        "naturalLandUse_Area": "Natural Land Use (Different type of lands (Forestry, agriculture, ... WIP)",
+        "observedEvent_Area": "Lava Flow (Lava flow area)",
+        "observedEvent_Point": "Current Vents (Current vents location. WIP)",
+        "physiography_Line": "Physiography (Relief lines)",
+        "transportation_Line": "Transportation (Damaged transportation infrastructure. WIP)",
     }
 
     return {k: v for k, v in layers_matcher.items() if k in layers}

--- a/app/data/copernicus_data.py
+++ b/app/data/copernicus_data.py
@@ -137,7 +137,7 @@ def overlay(name):
         return overlays.get(name)
 
 
-@cache.memoize(timeout=3600*24)
+@cache.memoize(timeout=3600*12)
 def get_copernicus_data():
 
     entries = copernicus_entries()

--- a/app/data/database.py
+++ b/app/data/database.py
@@ -1,13 +1,12 @@
 import logging
 import os
 
-from flask_caching import Cache
 import pandas as pd
 from urllib.parse import urlparse
 import psycopg2
 
 from .db_helper import tools
-from ..server import app
+from ..server import cache
 from . import calculations
 
 
@@ -17,13 +16,6 @@ DB_PORT = DB_URL.port
 DB_NAME = DB_URL.path[1:]
 DB_USER = DB_URL.username
 DB_PASS = DB_URL.password
-
-CACHE_CONFIG = {
-    'CACHE_TYPE': 'filesystem',
-    'CACHE_DIR': "/tmp/cached_master_df"
-}
-cache = Cache()
-cache.init_app(app.server, config=CACHE_CONFIG)
 
 
 def process_data(d):

--- a/app/server.py
+++ b/app/server.py
@@ -1,4 +1,6 @@
 from flask import Flask
+from flask_caching import Cache
+
 from dash import Dash, html
 import dash_bootstrap_components as dbc
 
@@ -14,3 +16,11 @@ external_stylesheets = [
 server = Flask('la-palma-data-viz')
 app = Dash(external_stylesheets=external_stylesheets, server=server)
 app.title = "la-palma-data-viz"
+
+CACHE_CONFIG = {
+    'CACHE_TYPE': 'filesystem',
+    'CACHE_DIR': "/tmp/cached_master_df"
+}
+cache = Cache()
+cache.init_app(app.server, config=CACHE_CONFIG)
+

--- a/app/viewModules/mapview.py
+++ b/app/viewModules/mapview.py
@@ -1,7 +1,8 @@
 from dash import html, dcc
 from ..components.map_options import map_option, map_overlay, map_type
 
-mapview_layout = html.Div(children=[
+def mapview_layout():
+    return html.Div(children=[
     html.H5("Earthquakes location colored by magnitude"),
     html.Div(
         [

--- a/app/viewModules/mapview.py
+++ b/app/viewModules/mapview.py
@@ -1,14 +1,18 @@
 from dash import html, dcc
+from ..components.map_options import map_option, map_overlay, map_type
 
 mapview_layout = html.Div(children=[
     html.H5("Earthquakes location colored by magnitude"),
-    dcc.Graph(
-        id='scatter-map-2d',
-        className="eq-map"
+    html.Div(
+        [
+            map_option(),
+            map_type(),
+            map_overlay(),
+        ],
+        className="map-options"
     ),
-    html.H5("Heatmap (Experimental)"),
     dcc.Graph(
-        id='heat-map-2d',
+        id='map-viz',
         className="eq-map"
     ),
 ])

--- a/assets/base-layout.css
+++ b/assets/base-layout.css
@@ -34,5 +34,37 @@
 
 .eq-map {
     padding-bottom: 10px;
-    height: 70vh
+    padding-top: 10px;
+    height: 90vh
+}
+
+.Select-control {
+    background-color: rgb(25, 25, 25) !important;
+}
+
+.has-value.Select--single > .Select-control .Select-value .Select-value-label {
+    color: rgb(255, 255, 255)
+}
+
+
+.Select-menu-outer {
+    background-color: rgb(25, 25, 25);
+}
+
+.map-options {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+}
+
+#map-style.dash-dropdown {
+    flex: 1 1 auto;
+}
+
+#map-overlay.dash-dropdown {
+    flex: 1 1 auto;
+}
+
+#map-type.dash-dropdown {
+    flex: 1 1 auto;
 }

--- a/requirements-dash.txt
+++ b/requirements-dash.txt
@@ -9,3 +9,4 @@ scikit-image
 lxml
 pykml
 dash-bootstrap-components
+georss_generic_client


### PR DESCRIPTION
## Changes

- cache is now declared in the server module so ti can be used by other modules more intelligently
- add 3 dropdown options for the map view
  - Map style: Change the base map (OSM, Stamen Terrain, ...)
  - Map type: Select the type of visualization (Scatter plot (default) or Heatmap)
  - Map overlay: Add an additional layer using data from Copernicus
- Heatmap has been replaced by an option to select the main map type
- Added the copernicus_data module to get the data from Copernicus

### copernicus_data module

- Fetches the latest mapping from Copernicus
- Save the zip file and extract all included  geojson to `/tmp`
- Return a dict of `key:value` with the layers fetched and their user-friendly names
- Another function is used to fetched the corresponding json layer based on name.